### PR TITLE
All categories

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.7
+current_version = 0.1.8
 commit = True
 tag = True
 tag_name = {new_version}

--- a/glitter_events/views.py
+++ b/glitter_events/views.py
@@ -69,15 +69,6 @@ class EventListCategoryView(CategoryMixin, EventListView):
     template_name_suffix = '_list_category'
 
     def get_queryset(self):
-        qs = super(EventListCategoryView, self).get_queryset()
-        self.category = get_object_or_404(Category, slug=self.kwargs['slug'])
-        return qs.filter(category=self.category)
-
-
-class EventListCategoryArchiveView(CategoryMixin, EventListArchiveView):
-    template_name_suffix = '_list_category_archive'
-
-    def get_queryset(self):
         """
         Categories such as 'all events' should return all categories, not just
         the events with category__title='all_events'. The name of this type of
@@ -92,6 +83,15 @@ class EventListCategoryArchiveView(CategoryMixin, EventListArchiveView):
         if hasattr(settings, 'ALL_EVENTS_CATEGORY_TITLE'):
             if self.category.title == settings.ALL_EVENTS_CATEGORY_TITLE:
                 return qs
+        return qs.filter(category=self.category)
+
+
+class EventListCategoryArchiveView(CategoryMixin, EventListArchiveView):
+    template_name_suffix = '_list_category_archive'
+
+    def get_queryset(self):
+        qs = super(EventListCategoryArchiveView, self).get_queryset()
+        self.category = get_object_or_404(Category, slug=self.kwargs['slug'])
         return qs.filter(category=self.category)
 
 

--- a/glitter_events/views.py
+++ b/glitter_events/views.py
@@ -83,14 +83,14 @@ class EventListCategoryArchiveView(CategoryMixin, EventListArchiveView):
         the events with category__title='all_events'. The name of this type of
         category could change for each separate site so a settings variable has
         been introduced so it can be set on a per-site basis.
-        If the title of the given category matches the ALL_CATEGORIES_TITLE for
+        If the title of the given category matches the ALL_EVENTS_CATEGORY_TITLE for
         the site, all events will be returned, otherwise, the category filter
         will be applied as normal.
         """
         qs = super(EventListCategoryArchiveView, self).get_queryset()
         self.category = get_object_or_404(Category, slug=self.kwargs['slug'])
-        if hasattr(settings, 'ALL_CATEGORIES_TITLE'):
-            if self.category.title == settings.ALL_CATEGORIES_TITLE:
+        if hasattr(settings, 'ALL_EVENTS_CATEGORY_TITLE'):
+            if self.category.title == settings.ALL_EVENTS_CATEGORY_TITLE:
                 return qs
         return qs.filter(category=self.category)
 

--- a/glitter_events/views.py
+++ b/glitter_events/views.py
@@ -78,7 +78,7 @@ class EventListCategoryView(CategoryMixin, EventListView):
         the site, all events will be returned, otherwise, the category filter
         will be applied as normal.
         """
-        qs = super(EventListCategoryArchiveView, self).get_queryset()
+        qs = super(EventListCategoryView, self).get_queryset()
         self.category = get_object_or_404(Category, slug=self.kwargs['slug'])
         if hasattr(settings, 'ALL_EVENTS_CATEGORY_TITLE'):
             if self.category.title == settings.ALL_EVENTS_CATEGORY_TITLE:

--- a/glitter_events/views.py
+++ b/glitter_events/views.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views.generic import ListView
@@ -77,8 +78,20 @@ class EventListCategoryArchiveView(CategoryMixin, EventListArchiveView):
     template_name_suffix = '_list_category_archive'
 
     def get_queryset(self):
+        """
+        Categories such as 'all events' should return all categories, not just
+        the events with category__title='all_events'. The name of this type of
+        category could change for each separate site so a settings variable has
+        been introduced so it can be set on a per-site basis.
+        If the title of the given category matches the ALL_CATEGORIES_TITLE for
+        the site, all events will be returned, otherwise, the category filter
+        will be applied as normal.
+        """
         qs = super(EventListCategoryArchiveView, self).get_queryset()
         self.category = get_object_or_404(Category, slug=self.kwargs['slug'])
+        if hasattr(settings, 'ALL_CATEGORIES_TITLE'):
+            if self.category.title == settings.ALL_CATEGORIES_TITLE:
+                return qs
         return qs.filter(category=self.category)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst', 'r', 'utf-8') as f:
 
 setup(
     name='django-glitter-events',
-    version='0.1.7',
+    version='0.1.8',
     description='Glitter Events for Django',
     long_description=readme,
     maintainer='The Developer Society',


### PR DESCRIPTION
For card: https://favro.com/organization/b03d6d6d9b11b61167ac4246/418c53a770389640d415a230?card=Dev-9685


Adding `ALL_EVENTS_CATEGORY_TITLE` into a site will now cause the site's 'All events' category to return all the events, instead of those just in the 'All events' category. This needs to be set on a per site basis incase the title of the category changes. If not in settings, the category filter will run as normal.

NOTE: this PR is to merge into **master**, just let me know if it should be going somewhere else!